### PR TITLE
Fix for snap.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,6 +17,8 @@ apps:
 parts:
   bzoing:
     source: https://github.com/lapisdecor/bzoing.git
+    source-type: git
+    source-branch: v1.0
     # See 'snapcraft plugins'
     plugin: python
     stage-packages:


### PR DESCRIPTION
* As suggested [here](https://snapcraft.io/docs/reference/plugins/source), there's a possibility to specify the branch and not the source tag only.
* This, hopefully, will help snapcraft know which branch to look for when building.
* source-type also specifies the type of version control system, which allegedly helps
resolving any urging issues from it.

