### PR TITLE
setting XDG_DATA_HOME appropriately

### DIFF
--- a/bzoing/tasks.py
+++ b/bzoing/tasks.py
@@ -6,10 +6,10 @@ from bzoing.playme import Playme
 import time
 import threading
 import subprocess
+from xdg.BaseDirectory import save_data_path
 
-share_dir = os.path.expanduser('~/.local/share/bzoing')
-if not os.path.isdir(share_dir):
-    os.makedirs(share_dir)
+
+share_dir = save_data_path("bzoing")
 
 
 @total_ordering


### PR DESCRIPTION
You will need a new symbolic link to xdg so things work on virtual environment. eg.
ln -s /usr/lib/python3/dist-packages/xdg ~/pathtovenv/venv/lib/python3.5/site-packages/