### PR TITLE
README: fixed snapcraft badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,9 +2,9 @@
 bzoing
 ======
 
-.. image:: https://build.snapcraft.io/badge/lapisdecor/bzoing.svg
-  :target: https://build.snapcraft.io/user/lapisdecor/bzoing
-      :alt: Snap Status
+.. image:: https://snapcraft.io/bzoing/badge.svg
+  :target: https://snapcraft.io/bzoing
+  :alt: Snap Status
 
 .. image:: /bzoingdemo.png
       :alt: bzoing demo


### PR DESCRIPTION
Both the link for the image and the target were
still in an old snapscraft format.

Also fixed the alt tag for that image.